### PR TITLE
Fix: Case sensitive file name

### DIFF
--- a/src/utilities/get-page-data.ts
+++ b/src/utilities/get-page-data.ts
@@ -10,7 +10,7 @@ import { trueCasePathSync } from './true-case-path'
 const getPagesSource = (source) => {
   if (source === 'components') {
     return path.resolve(
-      __dirname,
+      process.cwd(),
       'node_modules',
       '@atom-learning',
       'components',
@@ -21,7 +21,7 @@ const getPagesSource = (source) => {
 
   if (source === 'theme') {
     return path.resolve(
-      __dirname,
+      process.cwd(),
       'node_modules',
       '@atom-learning',
       'theme',
@@ -30,7 +30,7 @@ const getPagesSource = (source) => {
   }
 
   if (source === 'overview') {
-    return path.resolve(__dirname, 'content')
+    return path.resolve(process.cwd(), 'content')
   }
 
   return null

--- a/src/utilities/get-page-data.ts
+++ b/src/utilities/get-page-data.ts
@@ -5,9 +5,12 @@ import { paramCase } from 'param-case'
 import { pascalCase } from 'pascal-case'
 import path from 'path'
 
+import { trueCasePathSync } from './true-case-path'
+
 const getPagesSource = (source) => {
   if (source === 'components') {
-    return path.join(
+    return path.resolve(
+      __dirname,
       'node_modules',
       '@atom-learning',
       'components',
@@ -17,11 +20,17 @@ const getPagesSource = (source) => {
   }
 
   if (source === 'theme') {
-    return path.join('node_modules', '@atom-learning', 'theme', 'dist')
+    return path.resolve(
+      __dirname,
+      'node_modules',
+      '@atom-learning',
+      'theme',
+      'dist'
+    )
   }
 
   if (source === 'overview') {
-    return 'content'
+    return path.resolve(__dirname, 'content')
   }
 
   return null
@@ -42,12 +51,17 @@ export const getPagesSlugs = async (sources: string[]) => {
 }
 
 const getMarkdownFile = (basePath, name) => {
-  const filePathAsMdx = path.join(basePath, `${pascalCase(name)}.mdx`)
-  const filePathAsMd = path.join(basePath, `${pascalCase(name)}.md`)
+  // try to access .mdx initially, attempt .md after
+  // true-case-path will error if neither are found
+  try {
+    const file = trueCasePathSync(`${pascalCase(name)}.mdx`, basePath)
+    return fs.readFileSync(file, 'utf8')
+  } catch (err) {} // eslint-disable-line no-empty
 
-  const fileToRead = fs.existsSync(filePathAsMdx) ? filePathAsMdx : filePathAsMd
-
-  return fs.readFileSync(fileToRead, 'utf8')
+  try {
+    const file = trueCasePathSync(`${pascalCase(name)}.md`, basePath)
+    return fs.readFileSync(file, 'utf8')
+  } catch (err) {} // eslint-disable-line no-empty
 }
 
 export interface PageBySlug {

--- a/src/utilities/true-case-path.ts
+++ b/src/utilities/true-case-path.ts
@@ -1,0 +1,71 @@
+import { readdirSync } from 'fs'
+import { platform } from 'os'
+import { isAbsolute, normalize } from 'path'
+
+const isWindows = platform() === 'win32'
+const delimiter = isWindows ? '\\' : '/'
+
+export const trueCasePathSync = _trueCasePath()
+
+function getRelevantFilePathSegments(filePath) {
+  return filePath.split(delimiter).filter((s) => s !== '')
+}
+
+function escapeString(str) {
+  return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
+function matchCaseInsensitive(fileOrDirectory, directoryContents, filePath) {
+  const caseInsensitiveRegex = new RegExp(
+    `^${escapeString(fileOrDirectory)}$`,
+    'i'
+  )
+  for (const file of directoryContents) {
+    if (caseInsensitiveRegex.test(file)) return file
+  }
+  throw new Error(
+    `[true-case-path]: Called with ${filePath}, but no matching file exists`
+  )
+}
+
+function _trueCasePath() {
+  return (filePath, basePath) => {
+    if (basePath) {
+      if (!isAbsolute(basePath)) {
+        throw new Error(
+          `[true-case-path]: basePath argument must be absolute. Received "${basePath}"`
+        )
+      }
+      basePath = normalize(basePath)
+    }
+    filePath = normalize(filePath)
+    const segments = getRelevantFilePathSegments(filePath)
+    if (isAbsolute(filePath)) {
+      if (basePath) {
+        throw new Error(
+          '[true-case-path]: filePath must be relative when used with basePath'
+        )
+      }
+      basePath = isWindows
+        ? segments.shift().toUpperCase() // drive letter
+        : ''
+    } else if (!basePath) {
+      basePath = process.cwd()
+    }
+    return iterateSync(basePath, filePath, segments)
+  }
+}
+
+function iterateSync(basePath, filePath, segments) {
+  return segments.reduce(
+    (realPath, fileOrDirectory) =>
+      realPath +
+      delimiter +
+      matchCaseInsensitive(
+        fileOrDirectory,
+        readdirSync(realPath + delimiter),
+        filePath
+      ),
+    basePath
+  )
+}


### PR DESCRIPTION
- Had to utilise `trueCasePathSync` to read _case insensitive_ file names, OSX was fine, Linux was not having it
- The package `true-case-path` had a _weird_ error with the promisify method for it's async export that I couldn't get around so I just copied the bits that we need into our own utility (for now)