### PR TITLE
feat: link to gallery

### DIFF
--- a/src/content/introduction.mdx
+++ b/src/content/introduction.mdx
@@ -13,7 +13,7 @@ The design system is divided up into three main parts:
 - Information on the theme layer and underlying visual system that powers the design-system
 - Technical documentation on our component library
 
-Our main focus for this initial release has been to create the in-depth technical documentation for our [component library](/components/introduction). There is also an initial draft of the [theme](/theme/colours) content written, for use mainly as a visual reference for the scales and systems that form our design system.
+Our main focus for this initial release has been to create the in-depth technical documentation for our [component library](/components/introduction). There is also an initial draft of the [theme](/theme/colours) content written, for use mainly as a visual reference for the scales and systems that form our design system. We also have a [gallery view](/components) of all our components in one place.
 
 We're aiming to add a number of guidelines soon that talk not only about the components and how to use them, but also how best to combine them and use them in context for a greater user experience. We hope to include detailed guidance on more specific UX patterns like data capture through forms, consistent navigation patterns, tone of voice, how to best handle error & empty states, how to prioritise interface elements, and others.
 


### PR DESCRIPTION
Adds a link to the `/components` gallery view from the homepage.

<img width="1061" alt="Screenshot 2022-04-27 at 08 56 54" src="https://user-images.githubusercontent.com/21319237/165469882-41af8335-b211-4ffb-95f6-a7fdfcc5aa90.png">
