### PR TITLE
Int 34 add missing components to components page

### DIFF
--- a/src/sandbox/components.tsx
+++ b/src/sandbox/components.tsx
@@ -1373,6 +1373,11 @@ post.
         </NotificationBadge>
       </Group.Section>
     </Group>
+    <Group name="Date Input">
+      <Group.Section>
+        <DateInput />
+      </Group.Section>
+    </Group>
   </>
 )
 

--- a/src/sandbox/components.tsx
+++ b/src/sandbox/components.tsx
@@ -1062,6 +1062,32 @@ post.
               ]}
             />
           </Stack>
+          <Stack gap="2" direction="column">
+            <Label>Slider</Label>
+            <Slider defaultValue={[50]} css={{ width: '320px' }} />
+            <Slider defaultValue={[25, 75]} css={{ width: '320px' }} />
+            <Slider defaultValue={[50]} css={{ width: '320px' }}>
+              <Slider.Steps
+                min={0}
+                max={100}
+                steps={[
+                  { value: 0, label: 'min' },
+                  { value: 50, label: 'mid' },
+                  { value: 100, label: 'max' }
+                ]}
+              />
+            </Slider>
+            <Slider defaultValue={[50]} css={{ width: '320px' }}>
+              <Slider.Value value={[50]} />
+            </Slider>
+            <Box css={{ p: '$5', bg: '$tonal100' }}>
+              <Slider
+                theme="light"
+                defaultValue={[50]}
+                css={{ width: '320px' }}
+              />
+            </Box>
+          </Stack>
         </Form>
       </Group.Section>
       <Group.Section>
@@ -1320,37 +1346,6 @@ post.
         <Stepper.Steps />
         <Stepper.StepForward>Next</Stepper.StepForward>
       </Stepper>
-    </Group>
-    <Group name="Slider">
-      <Group.Section>
-        <Slider defaultValue={[50]} css={{ width: '320px' }} />
-      </Group.Section>
-      <Group.Section>
-        <Slider defaultValue={[25, 75]} css={{ width: '320px' }} />
-      </Group.Section>
-      <Group.Section>
-        <Slider defaultValue={[50]} css={{ width: '320px' }}>
-          <Slider.Steps
-            min={0}
-            max={100}
-            steps={[
-              { value: 0, label: 'min' },
-              { value: 50, label: 'mid' },
-              { value: 100, label: 'max' }
-            ]}
-          />
-        </Slider>
-      </Group.Section>
-      <Group.Section>
-        <Slider defaultValue={[50]} css={{ width: '320px' }}>
-          <Slider.Value value={[50]} />
-        </Slider>
-      </Group.Section>
-      <Group.Section>
-        <Box css={{ p: '$5', bg: '$tonal100' }}>
-          <Slider theme="light" defaultValue={[50]} css={{ width: '320px' }} />
-        </Box>
-      </Group.Section>
     </Group>
     <Group name="Dropdown menu">
       <DropdownMenu>

--- a/src/sandbox/components.tsx
+++ b/src/sandbox/components.tsx
@@ -1026,6 +1026,42 @@ post.
               <option value="grapes">Grapes</option>
             </Select>
           </Stack>
+          <Stack gap="2" direction="column">
+            <Label>Date Input</Label>
+            <DateInput />
+          </Stack>
+          <Stack gap="2" direction="column">
+            <Label>Initial Date</Label>
+            <DateInput initialDate={new Date()} />
+          </Stack>
+          <Stack gap="2" direction="column">
+            <Label>Date Format "YYYY/MM/DD"</Label>
+            <DateInput dateFormat="YYYY/MM/DD" />
+          </Stack>
+          <Stack gap="2" direction="column">
+            <Label>Dayzed customisation</Label>
+            <DateInput firstDayOfWeek={0} />
+          </Stack>
+          <Stack gap="2" direction="column">
+            <Label>Translations</Label>
+            <DateInput
+              weekdayNames={['D', 'L', 'M', 'X', 'J', 'V', 'S']}
+              monthNames={[
+                'Enero',
+                'Febrero',
+                'Marzo',
+                'Abril',
+                'Mayo',
+                'Junio',
+                'Julio',
+                'Agosto',
+                'Septiembre',
+                'Octubre',
+                'Noviembre',
+                'Diciembre'
+              ]}
+            />
+          </Stack>
         </Form>
       </Group.Section>
       <Group.Section>
@@ -1278,39 +1314,6 @@ post.
         </Accordion.Item>
       </Accordion>
     </Group>
-    <Group name="Combobox">
-      <Box css={{ width: '400px' }}>
-        <Label css={{ mb: '$3' }} htmlFor="someid">
-          What's your favourite fruit?
-        </Label>
-        <Combobox onSelect={console.log} openOnFocus>
-          <Combobox.Input id="someid" />
-          <Combobox.Popover>
-            <Combobox.List>
-              <Combobox.Option value="Apple" />
-              <Combobox.Option value="Banana" />
-              <Combobox.Option value="Cranberry" />
-              <Combobox.Option value="Dragon fruit" />
-
-              <Flex css={{ alignItems: 'center', p: '$2' }}>
-                <Input size="sm" placeholder="New fruit" />
-                <Button
-                  size="sm"
-                  css={{ ml: '$2' }}
-                  onClick={() =>
-                    alert(
-                      'Nest other interactive UI here for advanced usecases'
-                    )
-                  }
-                >
-                  Add a new fruit
-                </Button>
-              </Flex>
-            </Combobox.List>
-          </Combobox.Popover>
-        </Combobox>
-      </Box>
-    </Group>
     <Group name="Stepper">
       <Stepper stepCount={3}>
         <Stepper.StepBack>Back</Stepper.StepBack>
@@ -1371,51 +1374,6 @@ post.
             <Icon is={Controls} />
           </ActionIcon>
         </NotificationBadge>
-      </Group.Section>
-    </Group>
-    <Group name="Date Input">
-      <Group.Section>
-        <DateInput />
-      </Group.Section>
-      <Group.Section>
-        <Stack gap="2" direction="column">
-          <Label>Initial Date</Label>
-          <DateInput initialDate={new Date()} />
-        </Stack>
-      </Group.Section>
-      <Group.Section>
-        <Stack gap="2" direction="column">
-          <Label>Date Format "YYYY/MM/DD"</Label>
-          <DateInput dateFormat="YYYY/MM/DD" />
-        </Stack>
-      </Group.Section>
-      <Group.Section>
-        <Stack gap="2" direction="column">
-          <Label>Dayzed customisation</Label>
-          <DateInput firstDayOfWeek={0} />
-        </Stack>
-      </Group.Section>
-      <Group.Section>
-        <Stack gap="2" direction="column">
-          <Label>Translations</Label>
-          <DateInput
-            weekdayNames={['D', 'L', 'M', 'X', 'J', 'V', 'S']}
-            monthNames={[
-              'Enero',
-              'Febrero',
-              'Marzo',
-              'Abril',
-              'Mayo',
-              'Junio',
-              'Julio',
-              'Agosto',
-              'Septiembre',
-              'Octubre',
-              'Noviembre',
-              'Diciembre'
-            ]}
-          />
-        </Stack>
       </Group.Section>
     </Group>
   </>

--- a/src/sandbox/components.tsx
+++ b/src/sandbox/components.tsx
@@ -1377,6 +1377,46 @@ post.
       <Group.Section>
         <DateInput />
       </Group.Section>
+      <Group.Section>
+        <Stack gap="2" direction="column">
+          <Label>Initial Date</Label>
+          <DateInput initialDate={new Date()} />
+        </Stack>
+      </Group.Section>
+      <Group.Section>
+        <Stack gap="2" direction="column">
+          <Label>Date Format "YYYY/MM/DD"</Label>
+          <DateInput dateFormat="YYYY/MM/DD" />
+        </Stack>
+      </Group.Section>
+      <Group.Section>
+        <Stack gap="2" direction="column">
+          <Label>Dayzed customisation</Label>
+          <DateInput firstDayOfWeek={0} />
+        </Stack>
+      </Group.Section>
+      <Group.Section>
+        <Stack gap="2" direction="column">
+          <Label>Translations</Label>
+          <DateInput
+            weekdayNames={['D', 'L', 'M', 'X', 'J', 'V', 'S']}
+            monthNames={[
+              'Enero',
+              'Febrero',
+              'Marzo',
+              'Abril',
+              'Mayo',
+              'Junio',
+              'Julio',
+              'Agosto',
+              'Septiembre',
+              'Octubre',
+              'Noviembre',
+              'Diciembre'
+            ]}
+          />
+        </Stack>
+      </Group.Section>
     </Group>
   </>
 )

--- a/src/sandbox/components.tsx
+++ b/src/sandbox/components.tsx
@@ -11,6 +11,7 @@ import {
   DateInput,
   Dialog,
   Divider,
+  DropdownMenu,
   Flex,
   Form,
   Heading,
@@ -1345,6 +1346,21 @@ post.
           <Slider theme="light" defaultValue={[50]} css={{ width: '320px' }} />
         </Box>
       </Group.Section>
+    </Group>
+    <Group name="Dropdown menu">
+      <DropdownMenu>
+        <DropdownMenu.Trigger asChild>
+          <Button>Click me</Button>
+        </DropdownMenu.Trigger>
+        <DropdownMenu.Content sideOffset={16}>
+          <DropdownMenu.Item onClick={() => alert('Great clicking!')}>
+            Item 1
+          </DropdownMenu.Item>
+          <DropdownMenu.Item>Item 2</DropdownMenu.Item>
+          <DropdownMenu.Separator />
+          <DropdownMenu.LinkItem href="/logout">Log Out</DropdownMenu.LinkItem>
+        </DropdownMenu.Content>
+      </DropdownMenu>
     </Group>
   </>
 )

--- a/src/sandbox/components.tsx
+++ b/src/sandbox/components.tsx
@@ -8,6 +8,7 @@ import {
   Carousel,
   CheckboxField,
   Combobox,
+  DateInput,
   Dialog,
   Divider,
   Flex,
@@ -34,6 +35,7 @@ import {
   SelectField,
   Stack,
   StackContent,
+  Stepper,
   Switch,
   Table,
   Tabs,
@@ -1304,6 +1306,13 @@ post.
           </Combobox.Popover>
         </Combobox>
       </Box>
+    </Group>
+    <Group name="Stepper">
+      <Stepper stepCount={3}>
+        <Stepper.StepBack>Back</Stepper.StepBack>
+        <Stepper.Steps />
+        <Stepper.StepForward>Next</Stepper.StepForward>
+      </Stepper>
     </Group>
   </>
 )

--- a/src/sandbox/components.tsx
+++ b/src/sandbox/components.tsx
@@ -1272,6 +1272,39 @@ post.
         </Accordion.Item>
       </Accordion>
     </Group>
+    <Group name="Combobox">
+      <Box css={{ width: '400px' }}>
+        <Label css={{ mb: '$3' }} htmlFor="someid">
+          What's your favourite fruit?
+        </Label>
+        <Combobox onSelect={console.log} openOnFocus>
+          <Combobox.Input id="someid" />
+          <Combobox.Popover>
+            <Combobox.List>
+              <Combobox.Option value="Apple" />
+              <Combobox.Option value="Banana" />
+              <Combobox.Option value="Cranberry" />
+              <Combobox.Option value="Dragon fruit" />
+
+              <Flex css={{ alignItems: 'center', p: '$2' }}>
+                <Input size="sm" placeholder="New fruit" />
+                <Button
+                  size="sm"
+                  css={{ ml: '$2' }}
+                  onClick={() =>
+                    alert(
+                      'Nest other interactive UI here for advanced usecases'
+                    )
+                  }
+                >
+                  Add a new fruit
+                </Button>
+              </Flex>
+            </Combobox.List>
+          </Combobox.Popover>
+        </Combobox>
+      </Box>
+    </Group>
   </>
 )
 

--- a/src/sandbox/components.tsx
+++ b/src/sandbox/components.tsx
@@ -25,6 +25,7 @@ import {
   List,
   Loader,
   MarkdownContent,
+  NotificationBadge,
   PasswordField,
   Popover,
   ProgressBar,
@@ -56,6 +57,7 @@ import {
   ArrowRight,
   BatteryMedium,
   Bin,
+  Controls,
   Crossing,
   Download,
   Eye,
@@ -1361,6 +1363,15 @@ post.
           <DropdownMenu.LinkItem href="/logout">Log Out</DropdownMenu.LinkItem>
         </DropdownMenu.Content>
       </DropdownMenu>
+    </Group>
+    <Group name="Notification Badge">
+      <Group.Section>
+        <NotificationBadge value={3}>
+          <ActionIcon appearance="outline" size="lg" isRounded>
+            <Icon is={Controls} />
+          </ActionIcon>
+        </NotificationBadge>
+      </Group.Section>
     </Group>
   </>
 )

--- a/src/sandbox/components.tsx
+++ b/src/sandbox/components.tsx
@@ -1,5 +1,6 @@
 // @ts-nocheck
 import {
+  Accordion,
   ActionIcon,
   AlertProvider,
   Box,
@@ -1254,6 +1255,22 @@ post.
           </Dialog.Content>
         </Dialog>
       </Group.Section>
+    </Group>
+    <Group name="Accordion">
+      <Accordion type="single" defaultValue="1">
+        <Accordion.Item value="1">
+          <Accordion.Trigger>Accordion Header 1</Accordion.Trigger>
+          <Accordion.Content css={{ p: '$4' }}>
+            Accordion content 1
+          </Accordion.Content>
+        </Accordion.Item>
+        <Accordion.Item value="2">
+          <Accordion.Trigger>Accordion Header 2</Accordion.Trigger>
+          <Accordion.Content css={{ p: '$4' }}>
+            Accordion content 2
+          </Accordion.Content>
+        </Accordion.Item>
+      </Accordion>
     </Group>
   </>
 )

--- a/src/sandbox/components.tsx
+++ b/src/sandbox/components.tsx
@@ -33,6 +33,7 @@ import {
   SearchInput,
   Select,
   SelectField,
+  Slider,
   Stack,
   StackContent,
   Stepper,
@@ -1313,6 +1314,37 @@ post.
         <Stepper.Steps />
         <Stepper.StepForward>Next</Stepper.StepForward>
       </Stepper>
+    </Group>
+    <Group name="Slider">
+      <Group.Section>
+        <Slider defaultValue={[50]} css={{ width: '320px' }} />
+      </Group.Section>
+      <Group.Section>
+        <Slider defaultValue={[25, 75]} css={{ width: '320px' }} />
+      </Group.Section>
+      <Group.Section>
+        <Slider defaultValue={[50]} css={{ width: '320px' }}>
+          <Slider.Steps
+            min={0}
+            max={100}
+            steps={[
+              { value: 0, label: 'min' },
+              { value: 50, label: 'mid' },
+              { value: 100, label: 'max' }
+            ]}
+          />
+        </Slider>
+      </Group.Section>
+      <Group.Section>
+        <Slider defaultValue={[50]} css={{ width: '320px' }}>
+          <Slider.Value value={[50]} />
+        </Slider>
+      </Group.Section>
+      <Group.Section>
+        <Box css={{ p: '$5', bg: '$tonal100' }}>
+          <Slider theme="light" defaultValue={[50]} css={{ width: '320px' }} />
+        </Box>
+      </Group.Section>
     </Group>
   </>
 )


### PR DESCRIPTION
## Following components have been added to the components list

- Accordion
- Combobox 
- Date input
- Stepper
- Slider
- Dropdown menu
- Notification Badge

Edit: 
ComboBox- Already existing in the Form, so removed from the list now

[Ticket](https://atomlearningltd.atlassian.net/browse/INT-34)

<img width="754" alt="Screenshot 2022-05-04 at 15 29 05" src="https://user-images.githubusercontent.com/95242193/166691642-e72456b2-6dae-43c9-8549-17c1f1493079.png">

<img width="576" alt="Screenshot 2022-05-04 at 15 28 51" src="https://user-images.githubusercontent.com/95242193/166691644-9bb22e27-03f2-46ec-85d8-485b666b7283.png">

<img width="721" alt="Screenshot 2022-05-04 at 15 28 57" src="https://user-images.githubusercontent.com/95242193/166691627-3629f153-c4e1-450c-8110-b71b95d71a4c.png">
<img width="796" alt="Screenshot 2022-05-04 at 15 28 38" src="https://user-images.githubusercontent.com/95242193/166691631-e33e0c30-b34c-44ca-a830-2c679079481e.png">
<img width="561" alt="Screenshot 2022-05-04 at 15 29 01" src="https://user-images.githubusercontent.com/95242193/166691635-d26b7000-f04d-4d95-9842-016261188f0a.png">
<img width="805" alt="Screenshot 2022-05-04 at 15 28 42" src="https://user-images.githubusercontent.com/95242193/166691639-84664701-eaa5-4904-aad5-3c40640bac9a.png">

<img width="830" alt="Screenshot 2022-05-04 at 15 28 25" src="https://user-images.githubusercontent.com/95242193/166691616-01c7f381-2400-4a02-94d5-9fff0a8b1483.png">


